### PR TITLE
better differentiation between client and server requests

### DIFF
--- a/src/HttpClientInstrumentation.php
+++ b/src/HttpClientInstrumentation.php
@@ -36,7 +36,7 @@ final class HttpClientInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf('client request HTTP %s %s', $params[0], (string) $params[1]))
+                    ->spanBuilder(\sprintf('HTTP %s %s', $params[0], parse_url($params[1], PHP_URL_HOST)))
                     ->setSpanKind(SpanKind::KIND_CLIENT)
                     ->setAttribute(TraceAttributes::HTTP_URL, (string) $params[1])
                     ->setAttribute(TraceAttributes::HTTP_METHOD, $params[0])

--- a/src/HttpClientInstrumentation.php
+++ b/src/HttpClientInstrumentation.php
@@ -36,7 +36,7 @@ final class HttpClientInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf('HTTP %s', $params[0]))
+                    ->spanBuilder(\sprintf('client request HTTP %s %s', $params[0], (string) $params[1]))
                     ->setSpanKind(SpanKind::KIND_CLIENT)
                     ->setAttribute(TraceAttributes::HTTP_URL, (string) $params[1])
                     ->setAttribute(TraceAttributes::HTTP_METHOD, $params[0])

--- a/src/SymfonyInstrumentation.php
+++ b/src/SymfonyInstrumentation.php
@@ -40,7 +40,11 @@ final class SymfonyInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf('HTTP %s', $request?->getMethod() ?? 'unknown'))
+                    ->spanBuilder(\sprintf(
+                        'server request HTTP %s %s',
+                        $request?->getMethod() ?? 'unknown',
+                        $request?->getUri() ?? 'unknown'
+                    ))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)

--- a/src/SymfonyInstrumentation.php
+++ b/src/SymfonyInstrumentation.php
@@ -40,11 +40,7 @@ final class SymfonyInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf(
-                        'server request HTTP %s %s',
-                        $request?->getMethod() ?? 'unknown',
-                        $request?->getUri() ?? 'unknown'
-                    ))
+                    ->spanBuilder(\sprintf('HTTP %s', $request?->getMethod() ?? 'unknown method'))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
@@ -83,6 +79,15 @@ final class SymfonyInstrumentation
                 $span = Span::fromContext($scope->context());
 
                 $request = ($params[0] instanceof Request) ? $params[0] : null;
+
+                if ($params[1] === HttpKernelInterface::MAIN_REQUEST) {
+                    $span->updateName(\sprintf(
+                        'HTTP %s %s',
+                        $request?->getMethod() ?? 'unknown method',
+                        $request?->attributes->get('_route', 'unknown route')
+                    ));
+                }
+
                 if (null !== $request) {
                     $routeName = $request->attributes->get('_route', '');
 


### PR DESCRIPTION
Hi! I suggest some small modifications to the description of spans for better readability. Therefore, I've added the type of the request, whether it's client or server, along with the URL, in the description. What do you think?